### PR TITLE
3961: Allow non-submission related jobs to be retried

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -53,7 +53,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -85,7 +85,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tillod jobs uden relation til indsendelser at blive genkørt.
+
 ## [1.5.1] 2024-10-02
 
 * Tilføejde primary key til relationstabellen.

--- a/src/Form/RetryJob.php
+++ b/src/Form/RetryJob.php
@@ -62,7 +62,6 @@ final class RetryJob extends ConfirmFormBase {
       return $this->t('Job not found');
     }
 
-
     $webformId = $this->helper->getWebformIdFromQueue($job->getId());
 
     if (NULL !== $webformId) {

--- a/src/Form/RetryJob.php
+++ b/src/Form/RetryJob.php
@@ -62,12 +62,18 @@ final class RetryJob extends ConfirmFormBase {
       return $this->t('Job not found');
     }
 
+
     $webformId = $this->helper->getWebformIdFromQueue($job->getId());
 
-    return $this->t('Are you sure you want to retry queue job related to Webform: @webformId, Submission id: @serialId', [
-      '@serialId' => $this->helper->getSubmissionSerialIdFromJob($job->getId()),
-      '@webformId' => $this->entityTypeManager->getStorage('webform')->load($webformId)->label(),
-    ]);
+    if (NULL !== $webformId) {
+      return $this->t('Are you sure you want to retry queue job related to Webform: @webformId, Submission id: @serialId', [
+        '@serialId' => $this->helper->getSubmissionSerialIdFromJob($job->getId()),
+        '@webformId' => $this->entityTypeManager->getStorage('webform')->load($webformId)->label(),
+      ]);
+    }
+    else {
+      return $this->t('Are you sure you want to retry queue job: @jobId', ['@jobId' => $job->getId()]);
+    }
   }
 
   /**
@@ -76,7 +82,15 @@ final class RetryJob extends ConfirmFormBase {
   public function getCancelUrl(): Url {
     $webform = $this->helper->getWebformIdFromQueue((string) $this->jobId);
 
-    return Url::fromRoute('entity.webform.error_log', ['webform' => $webform]);
+    if (NULL === $webform) {
+      $job = $this->helper->getJobFromId((string) $this->jobId);
+
+      return Url::fromRoute('view.advancedqueue_jobs.page_1', ['arg_0' => $job->getQueueId()]);
+    }
+    else {
+      return Url::fromRoute('entity.webform.error_log', ['webform' => $webform]);
+    }
+
   }
 
   /**

--- a/src/Form/RetryJob.php
+++ b/src/Form/RetryJob.php
@@ -64,14 +64,14 @@ final class RetryJob extends ConfirmFormBase {
 
     $webformId = $this->helper->getWebformIdFromQueue($job->getId());
 
-    if (NULL !== $webformId) {
+    if (NULL === $webformId) {
+      return $this->t('Are you sure you want to retry queue job: @jobId', ['@jobId' => $job->getId()]);
+    }
+    else {
       return $this->t('Are you sure you want to retry queue job related to Webform: @webformId, Submission id: @serialId', [
         '@serialId' => $this->helper->getSubmissionSerialIdFromJob($job->getId()),
         '@webformId' => $this->entityTypeManager->getStorage('webform')->load($webformId)->label(),
       ]);
-    }
-    else {
-      return $this->t('Are you sure you want to retry queue job: @jobId', ['@jobId' => $job->getId()]);
     }
   }
 

--- a/src/Helper/Helper.php
+++ b/src/Helper/Helper.php
@@ -153,7 +153,9 @@ class Helper {
     $query->condition('job_id', $jobId, '=');
     $query->fields('o', ['webform_id']);
 
-    return $query->execute()?->fetchObject()?->webform_id;
+    $result = $query->execute()?->fetchObject();
+
+    return $result ? $result->webform_id : NULL;
   }
 
   /**


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/3961

#### Description

* Allows non-submission related jobs to be retried through the UI.
  * Fixes `getCancelUrl` and `getQuestion` methods.

#### Screenshot of the result

N/A

#### Checklist

- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

N/A
